### PR TITLE
Add binary upload to CI

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -13,8 +13,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Build
         run: cargo build --verbose
+
+      - name: Upload binary
+        if: success()
+        uses: actions/upload-artifact@v3
+        with:
+          name: binary
+          path: target/debug/rust-game-server
+
       - name: Test
         run: cargo test --verbose


### PR DESCRIPTION
Upon a successful build step, CI will upload the generated binary as an artifact. This enables the download and execution of the binary without having to clone the repo and build.