### PR TITLE
Add fmt and clippy checks to CI

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -28,3 +28,9 @@ jobs:
 
       - name: Test
         run: cargo test --verbose
+
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{connection::Connection, server};
 use crate::server::Outcome;
+use crate::{connection::Connection, server};
 
 pub struct Client {
     player_one: Player,
@@ -58,10 +58,13 @@ impl Client {
         println!("Player {}'s turn!", player.icon);
 
         let move_index = player.get_move();
-        let _ = self.connection.write_event(Event::MoveMade {
-            player_id,
-            move_index,
-        }).await;
+        let _ = self
+            .connection
+            .write_event(Event::MoveMade {
+                player_id,
+                move_index,
+            })
+            .await;
     }
 
     pub async fn play_game(&mut self) {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::fmt::Formatter;
+
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use thiserror::__private::DisplayAsDisplay;
@@ -13,7 +14,7 @@ pub struct Connection {
 }
 
 impl Connection {
-    pub fn new(id: u8, stream: TcpStream) -> Connection{
+    pub fn new(id: u8, stream: TcpStream) -> Connection {
         Connection { id, stream }
     }
 
@@ -61,7 +62,7 @@ impl Connection {
 #[derive(thiserror::Error, Debug)]
 pub enum ReadWriteError {
     Serde(#[from] serde_json::Error),
-    StreamReadWrite(#[from] std::io::Error)
+    StreamReadWrite(#[from] std::io::Error),
 }
 
 impl fmt::Display for ReadWriteError {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
-mod client;
-mod server;
-mod connection;
-
 use tokio::net::{TcpListener, TcpStream};
+
 use crate::{client::Client, connection::Connection};
+
+mod client;
+mod connection;
+mod server;
 
 #[tokio::main]
 async fn main() {

--- a/src/server.rs
+++ b/src/server.rs
@@ -111,7 +111,7 @@ impl Server {
             state,
             board_cells: cells_event_rep,
         })
-            .await;
+        .await;
     }
 
     async fn dispatch_player_turn_event(&mut self) {
@@ -158,18 +158,14 @@ impl PartialEq for Player {
 }
 
 impl Player {
-    pub fn new_player_one(
-        connection: Connection,
-    ) -> Player {
+    pub fn new_player_one(connection: Connection) -> Player {
         Player {
             id: PLAYER_ONE_ID,
             connection,
         }
     }
 
-    pub fn new_player_two(
-        connection: Connection,
-    ) -> Player {
+    pub fn new_player_two(connection: Connection) -> Player {
         Player {
             id: PLAYER_TWO_ID,
             connection,
@@ -254,8 +250,8 @@ impl Board {
         // If first cell is occupied, check for win in first row, column, and left diagonal
         if self.cells[0].is_occupied()
             && ((self.cells[0] == self.cells[1] && self.cells[0] == self.cells[2])
-            || (self.cells[0] == self.cells[3] && self.cells[0] == self.cells[6])
-            || (self.cells[0] == self.cells[4] && self.cells[0] == self.cells[8]))
+                || (self.cells[0] == self.cells[3] && self.cells[0] == self.cells[6])
+                || (self.cells[0] == self.cells[4] && self.cells[0] == self.cells[8]))
         {
             return Some(Outcome::WinnerFound {
                 player_id: self.cells[0].get_occupying_player_id(),
@@ -275,7 +271,7 @@ impl Board {
         // Check for win in third column and right diagonal
         if self.cells[2].is_occupied()
             && ((self.cells[2] == self.cells[5] && self.cells[2] == self.cells[8])
-            || (self.cells[2] == self.cells[4] && self.cells[2] == self.cells[6]))
+                || (self.cells[2] == self.cells[4] && self.cells[2] == self.cells[6]))
         {
             return Some(Outcome::WinnerFound {
                 player_id: self.cells[2].get_occupying_player_id(),


### PR DESCRIPTION
Increases the robustness of the CI checks by introducing formatting and linting via the use of `cargo fmt` and `cargo clippy` commands.