### PR TITLE
Enhance Server-side Event Loop and State Representation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ async fn main() {
 
         // Play the game
         let mut server = server::Server::new(player_one, player_two);
-        server.play_game().await;
+        server.init().await;
     });
 
     // Spawn a thread for a single player


### PR DESCRIPTION
Changes made:
- Implemented a Server-side event loop so that the Server now operates using an event-driven design, where it sends and receives messages internally as well as externally.
- Introduces a new Server state `PreInitialise` to better manage the Server's state throughout the game lifecycle. This state represents the phase before the game has begun, which allows the Server to handle it's signal to begin the game.
- Refactored the `StateChanged` event and split into two separate events to enhance modularity and clarity. The new `BoardUpdated` event is responsible for signaling updates to the board view, allowing clients to visually reflect the latest game state. The `GameOver` event now explicitly indicates the end of the game and initiates the process of a graceful shutdown.