### PR TITLE
Improve game agnosticism for Client and Server

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,16 +1,13 @@
 use std::io;
-use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Receiver;
 
 use crate::connection::{Connection, ReadError, WriteError};
-use crate::game::{GameClient, GameClientEvent};
+use crate::game::{Game, GameClient, GameClientEvent};
 use crate::server;
-use crate::tic_tac_toe::{self, TicTacToeClient};
+use crate::tic_tac_toe::TicTacToeClient;
 
 pub trait ClientType {}
 
@@ -24,86 +21,79 @@ pub struct OnlineClient {
 
 impl ClientType for OnlineClient {}
 
-pub struct Client<O, GE, G, GSE>
+pub struct Client<'a, O>
 where
-    O: io::Write + Send + Sync,
-    GE: Serialize + DeserializeOwned + Send,
-    G: GameClient<GSE>,
-    GSE: DeserializeOwned + Send,
+    O: io::Write + Send + Sync + 'a,
 {
     running: bool,
     server_connection: Connection,
     user_output: Arc<Mutex<O>>,
-    game: G,
-    game_receiver: Receiver<GameClientEvent<GE>>,
-    game_server_event_type: PhantomData<GSE>,
+    game: Box<dyn GameClient + 'a>,
+    game_receiver: Receiver<GameClientEvent>,
 }
 
-impl<O, GE, G, GSE> Client<O, GE, G, GSE>
+impl<'a, O> Client<'a, O>
 where
-    O: io::Write + Send + Sync,
-    GE: Serialize + DeserializeOwned + Send,
-    G: GameClient<GSE>,
-    GSE: DeserializeOwned + Send,
+    O: io::Write + Send + Sync + 'a,
 {
-    pub fn new_local_tic_tac_toe<I: io::BufRead + Send + Sync>(
+    pub fn new_local<I: io::BufRead + Send + Sync + 'a>(
         connection: Connection,
         input: I,
         output: O,
-    ) -> Client<
-        O,
-        tic_tac_toe::ClientEvent,
-        TicTacToeClient<I, O, LocalClient>,
-        tic_tac_toe::ServerEvent,
-    > {
+        game: Game,
+    ) -> Client<'a, O> {
         let (game_sender, game_receiver) = mpsc::channel(10);
         let output = Arc::new(Mutex::new(output));
         let output_clone = Arc::clone(&output);
+
+        let game = match game {
+            Game::TicTacToe => Box::new(TicTacToeClient::new(
+                input,
+                output_clone,
+                game_sender,
+                LocalClient {},
+            )),
+        };
 
         Client {
             running: true,
             server_connection: connection,
             user_output: output,
-            game: TicTacToeClient::new(input, output_clone, game_sender, LocalClient {}),
+            game,
             game_receiver,
-            game_server_event_type: PhantomData,
         }
     }
 
-    pub fn new_online_tic_tac_toe<I: io::BufRead + Send + Sync>(
+    pub fn new_online<I: io::BufRead + Send + Sync + 'a>(
         connection: Connection,
         id: u8,
         input: I,
         output: O,
-    ) -> Client<
-        O,
-        tic_tac_toe::ClientEvent,
-        TicTacToeClient<I, O, OnlineClient>,
-        tic_tac_toe::ServerEvent,
-    > {
+        game: Game,
+    ) -> Client<'a, O> {
         let (game_sender, game_receiver) = mpsc::channel(10);
         let output = Arc::new(Mutex::new(output));
         let output_clone = Arc::clone(&output);
+
+        let game = match game {
+            Game::TicTacToe => Box::new(TicTacToeClient::new(
+                input,
+                output_clone,
+                game_sender,
+                OnlineClient { id },
+            )),
+        };
 
         Client {
             running: true,
             server_connection: connection,
             user_output: output,
-            game: TicTacToeClient::new(input, output_clone, game_sender, OnlineClient { id }),
+            game,
             game_receiver,
-            game_server_event_type: PhantomData,
         }
     }
-}
 
-impl<O, GE, G, GSE> Client<O, GE, G, GSE>
-where
-    O: io::Write + Send + Sync,
-    GE: Serialize + DeserializeOwned + Send,
-    G: GameClient<GSE>,
-    GSE: DeserializeOwned + Send,
-{
-    async fn get_next_incoming_event(&mut self) -> Result<IncomingEvent<GSE, GE>, ReadError> {
+    async fn get_next_incoming_event(&mut self) -> Result<IncomingEvent, ReadError> {
         tokio::select! {
             result = self.game_receiver.recv() => Ok(IncomingEvent::Game(result.unwrap())),
             result = self.server_connection.read_event() => result.map(IncomingEvent::Server),
@@ -123,29 +113,23 @@ where
         }
     }
 
-    pub async fn handle_event(&mut self, event: IncomingEvent<GSE, GE>) -> Result<(), WriteError> {
+    pub async fn handle_event(&mut self, event: IncomingEvent) -> Result<(), Error> {
         match event {
-            IncomingEvent::Server(server_event) => {
-                match server_event {
-                    server::OutgoingEvent::ErrorOccurred(error) => self.handle_error(error),
-                    server::OutgoingEvent::GameStarted => {
-                        self.game.handle_game_started_event().await
-                    }
-                    server::OutgoingEvent::Shutdown => self.handle_shutdown().await,
-                    server::OutgoingEvent::Game { event } => self.game.handle_event(event).await,
-                };
-                Ok(())
-            }
+            IncomingEvent::Server(server_event) => match server_event {
+                server::OutgoingEvent::ErrorOccurred(error) => self.handle_error(error),
+                server::OutgoingEvent::GameStarted => self.game.handle_game_started_event().await,
+                server::OutgoingEvent::Shutdown => self.handle_shutdown().await,
+                server::OutgoingEvent::Game { event } => self.game.handle_event(event).await?,
+            },
             IncomingEvent::Game(game_event) => match game_event {
                 GameClientEvent::DispatchToServer { event } => {
-                    self.server_connection.write_event(event).await
+                    self.server_connection.write_event(&event).await?
                 }
-                GameClientEvent::GameOver => {
-                    self.shutdown().await;
-                    Ok(())
-                }
+                GameClientEvent::GameOver => self.shutdown().await,
             },
-        }
+        };
+
+        Ok(())
     }
 
     fn handle_error(&self, error: server::Error) {
@@ -153,11 +137,10 @@ where
     }
 
     async fn handle_shutdown(&mut self) {
-        writeln!(
+        let _ = writeln!(
             &mut self.user_output.lock().unwrap(),
             "An unrecoverable error has occurred, game terminating."
-        )
-        .unwrap();
+        );
 
         self.shutdown().await
     }
@@ -168,9 +151,17 @@ where
     }
 }
 
-pub enum IncomingEvent<SE: DeserializeOwned, GE: Serialize + DeserializeOwned> {
-    Server(server::OutgoingEvent<SE>),
-    Game(GameClientEvent<GE>),
+pub enum IncomingEvent {
+    Server(server::OutgoingEvent),
+    Game(GameClientEvent),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Failed to write to stream")]
+    Write(#[from] WriteError),
+    #[error("Failed to read or write from user")]
+    Read(#[from] io::Error),
 }
 
 #[cfg(test)]
@@ -187,33 +178,28 @@ mod tests {
         TcpStream::connect(local_addr).await.unwrap()
     }
 
-    async fn get_local_test_client<'a>(
-        input: &'a [u8],
-        output: &'a mut Vec<u8>,
-    ) -> Client<
-        &'a mut Vec<u8>,
-        tic_tac_toe::ClientEvent,
-        TicTacToeClient<&'a [u8], &'a mut Vec<u8>, LocalClient>,
-        tic_tac_toe::ServerEvent,
-    > {
-        Client::<
-            &'a mut Vec<u8>,
-            tic_tac_toe::ClientEvent,
-            TicTacToeClient<&'a [u8], &'a mut Vec<u8>, LocalClient>,
-            tic_tac_toe::ServerEvent,
-        >::new_local_tic_tac_toe(Connection::new(get_test_stream().await), input, output)
+    async fn get_local_test_client<'a>(output: &'a mut Vec<u8>) -> Client<'a, &'a mut Vec<u8>> {
+        Client::<'a, &'a mut Vec<u8>>::new_local(
+            Connection::new(get_test_stream().await),
+            &b""[..],
+            output,
+            Game::TicTacToe,
+        )
     }
 
     #[tokio::test]
     async fn generic_client_handles_shutdown_event_from_server() {
         let mut output = Vec::new();
-        let mut client = get_local_test_client(&[], &mut output).await;
 
-        client
-            .handle_event(IncomingEvent::Server(server::OutgoingEvent::Shutdown))
-            .await
-            .unwrap();
-        assert_eq!(client.running, false);
+        {
+            let mut client = get_local_test_client(&mut output).await;
+            client
+                .handle_event(IncomingEvent::Server(server::OutgoingEvent::Shutdown))
+                .await
+                .unwrap();
+            assert_eq!(client.running, false);
+        }
+
         assert_eq!(
             output,
             b"An unrecoverable error has occurred, game terminating.\n"
@@ -223,15 +209,18 @@ mod tests {
     #[tokio::test]
     async fn generic_client_handles_error_event_from_server() {
         let mut output = Vec::new();
-        let mut client = get_local_test_client(&[], &mut output).await;
 
-        client
-            .handle_event(IncomingEvent::Server(server::OutgoingEvent::ErrorOccurred(
-                server::Error::InvalidMessage,
-            )))
-            .await
-            .unwrap();
-        assert_eq!(client.running, true);
+        {
+            let mut client = get_local_test_client(&mut output).await;
+            client
+                .handle_event(IncomingEvent::Server(server::OutgoingEvent::ErrorOccurred(
+                    server::Error::InvalidMessage,
+                )))
+                .await
+                .unwrap();
+            assert_eq!(client.running, true);
+        }
+
         assert_eq!(output, b"Error: Invalid message sent.\n")
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -13,8 +13,8 @@ impl Connection {
         Connection { stream }
     }
 
-    pub async fn write_event<T: Serialize>(&mut self, event: T) -> Result<(), WriteError> {
-        let serialised = serde_json::to_string(&event)?;
+    pub async fn write_event<T: Serialize>(&mut self, event: &T) -> Result<(), WriteError> {
+        let serialised = serde_json::to_string(event)?;
         let len = serialised.len() as u16;
         let bytes = len.to_be_bytes();
 
@@ -30,7 +30,7 @@ impl Connection {
         let mut len_bytes = [0; 2];
         self.stream.read_exact(&mut len_bytes).await?;
         let len = u16::from_be_bytes(len_bytes);
-        if len > 250 {
+        if len > 500 {
             return Err(ReadError::InvalidMessageLength);
         }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,32 +1,45 @@
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use std::io;
 
 use crate::server::DispatchMode;
 
+pub enum Game {
+    TicTacToe,
+}
+
 #[derive(Debug)]
-pub enum GameServerEvent<E: Serialize + DeserializeOwned> {
+pub enum GameServerEvent {
     DispatchToClient {
         dispatch_mode: DispatchMode,
-        event: E,
+        event: Vec<u8>,
     },
     GameOver,
 }
 
 #[async_trait]
-pub trait GameServer<E: DeserializeOwned> {
+pub trait GameServer {
     async fn begin(&self);
-    async fn handle_event(&mut self, event: E);
+    async fn handle_event(&mut self, event: Vec<u8>);
 }
 
 #[derive(Debug, PartialEq)]
-pub enum GameClientEvent<E: Serialize + DeserializeOwned> {
-    DispatchToServer { event: E },
+pub enum GameClientEvent {
+    DispatchToServer { event: Vec<u8> },
     GameOver,
 }
 
 #[async_trait]
-pub trait GameClient<E: DeserializeOwned> {
+pub trait GameClient {
     async fn handle_game_started_event(&self);
-    async fn handle_event(&mut self, event: E);
+    async fn handle_event(&mut self, event: Vec<u8>) -> Result<(), io::Error>;
+}
+
+pub fn serialize_event(event: impl Serialize) -> Vec<u8> {
+    serde_json::to_vec(&event).unwrap()
+}
+
+pub fn deserialize_event<T: DeserializeOwned>(event: Vec<u8>) -> T {
+    serde_json::from_slice(&event).unwrap()
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -363,8 +363,10 @@ async fn online_game_handles_client_sending_malicious_message() {
         .unwrap();
 
     // Client two receives invalid message error and shutdown request
-    let mut buf = String::new();
-    stream.read_to_string(&mut buf).await.unwrap();
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).await.unwrap();
+    let buf = String::from_utf8_lossy(&buf);
+
     assert!(buf.contains("InvalidMessage"));
     assert!(buf.contains("Shutdown"));
 


### PR DESCRIPTION
An attempt to add a new game to the project revealed that the previous changes to make the Client and Server game-agnostic were not sufficient. This was due to needing to declare trait types at struct instantiation, resulting in unknown types at compile time.

This commit adds the following fixes:
- Updated game-specific messages to be converted to Vectors before being sent between the Client and Server, eliminating the need to declare the types of the game messages within structs.
- Boxes the `GameClient` and `GameServer` trait types within their respective structs, providing the required flexibility for dynamic type resolution at runtime.

Additionally, the following changes have been made:
- Introduced a `Game` enum to hold the possible game variation to facilitate the instantiation of different games within more generic Client and Server constructors.
- Enhanced the error handling for client disconnections during read and write operations, mitigating found runtime errors when interacting with disconnected clients.